### PR TITLE
Indexed pull

### DIFF
--- a/KindredLogistics.csproj
+++ b/KindredLogistics.csproj
@@ -24,7 +24,7 @@
 	  <PackageReference Include="BepInEx.Core" Version="6.0.0-be.691" IncludeAssets="compile" />
 	  <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
 	  <PackageReference Include="VRising.Unhollowed.Client" Version="1.0.2.*" />
-	  <PackageReference Include="VRising.VampireCommandFramework" Version="0.9.*" />
+	  <PackageReference Include="VRising.VampireCommandFramework" Version="0.9.0" />
   </ItemGroup>
   <ItemGroup>
       <PackageReference Include="System.Text.Json" Version="6.0.1" />

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ PLEASE READ THE FEATURE SUMMARY AT THE BOTTOM OF THIS PAGE FOR A QUICK OVERVIEW 
   - Find item beams will only be present for one beam per chest. So if two players are searching planks on the same plot, only one will keep the beam.
   - Check what you have enabled with `.l s` if you feel a system isn't working.
   - Stash will only send out items that exactly match that which you have stored. If it doesn't stash, you don't have a chest with that item in it, or the chest is full.
+  - If a search query for an item returns multiple results, you can select it with :index.
+  - Example: `.pull (item:1) (quantity)` to get the first result when more than one result is returned.
     
  
 

--- a/nuget.config
+++ b/nuget.config
@@ -3,5 +3,6 @@
   <packageSources>
     <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json" />
     <add key="Samboy Feed" value="https://nuget.samboy.dev/v3/index.json" />
+	<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Yo, 

I made a small tweak to the FindItem method. It was kinda bugging me when I tried to ".pull bloodessence 10" and got multiple results, making it impossible to grab the regular bloodessence from the chest. Not sure if there's already a fix for this, but I couldn't find it, so I just made my own solution. Now, when you get multiple results, you can use ":[index]" to specify which one you want.

For example, with the blood essence, you can now do stuff like ".pull bloodessence:1 10" to retrieve the basic bloodessence, or ".pull bloodessence:2 10" for the greater blood essence, and so on.

It's just a small tweak, and I want to give something back by making this pull request.

Cheers!